### PR TITLE
mistake in yaw angles of intertial frame (turbines.YawIF)

### DIFF
--- a/floris_loadSettings.m
+++ b/floris_loadSettings.m
@@ -49,7 +49,7 @@ switch siteType
 end
 
 % Compute windDirection in the inertial frame, and the wind-aligned flow speed (uInfWf)
-inputData.windDirection = atand(inputData.vInfIf/inputData.uInfIf); % Wind dir in degrees (inertial frame)
+inputData.windDirection = atan(inputData.vInfIf/inputData.uInfIf); % Wind dir in radians (inertial frame)
 inputData.uInfWf        = hypot(inputData.uInfIf,inputData.vInfIf); % axial flow speed in wind frame
 
 

--- a/functions/floris_frame.m
+++ b/functions/floris_frame.m
@@ -30,6 +30,6 @@ function [ turbines,wtRows ] = floris_frame( inputData,turbines )
         turbines(i).LocIF = inputData.LocIF(sortvector(i),:).';
         turbines(i).LocWF = wtLocationsWf(i,:).';
         % Yaw angles (counterclockwise, inertial frame)
-        turbines(i).YawIF = inputData.windDirection+turbines(i).YawWF;
+        turbines(i).YawIF = deg2rad(inputData.windDirection)+turbines(i).YawWF;
     end;
 end

--- a/functions/floris_frame.m
+++ b/functions/floris_frame.m
@@ -8,7 +8,7 @@ function [ turbines,wtRows ] = floris_frame( inputData,turbines )
     Rz = @(a) [cos(a) -sin(a) 0;sin(a) cos(a) 0;0 0 1]; % Rotational matrix
     
     % Wind frame turbine locations in wind frame
-    wtLocationsWf = inputData.LocIF*Rz(deg2rad(-inputData.windDirection)).'; 
+    wtLocationsWf = inputData.LocIF*Rz(-inputData.windDirection).'; 
 
     % Order turbines from front to back, and project them on positive axes
     [LocX,sortvector] = sort(wtLocationsWf(:,1));

--- a/functions/floris_frame.m
+++ b/functions/floris_frame.m
@@ -30,6 +30,6 @@ function [ turbines,wtRows ] = floris_frame( inputData,turbines )
         turbines(i).LocIF = inputData.LocIF(sortvector(i),:).';
         turbines(i).LocWF = wtLocationsWf(i,:).';
         % Yaw angles (counterclockwise, inertial frame)
-        turbines(i).YawIF = deg2rad(inputData.windDirection)+turbines(i).YawWF;
+        turbines(i).YawIF = inputData.windDirection+turbines(i).YawWF;
     end;
 end


### PR DESCRIPTION
inputData.windDirection is defined in degrees (see floris_loadSettings.m)
turbines.YawIF seems to be only used in plot_layout.m (which now gives a correct plot of turbines in the inertial frame)